### PR TITLE
テストを追加する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 game:
 	python main.py
 
+test:
+	python -m pytest
+
 lint:
 	black --check .
 	flake8 .

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 ## Usage
 
+### Play game
 ```bash
 make
+```
+
+## For developer
+```bash
+make format
+make lint
+make test
 ```

--- a/logic/board.py
+++ b/logic/board.py
@@ -40,10 +40,10 @@ class Board:
         return self._is_connected_line(pos, Point(1, 0))
 
     def _is_connected_right_diagonal(self, pos: Point) -> bool:
-        return self._is_connected_line(pos, Point(1, -1))
+        return self._is_connected_line(pos, Point(-1, 1))
 
     def _is_connected_left_diagonal(self, pos: Point) -> bool:
-        return self._is_connected_line(pos, Point(-1, 1))
+        return self._is_connected_line(pos, Point(1, 1))
 
     def _is_connected_line(self, pos: Point, delta: Point) -> bool:
         count = 1

--- a/logic/connect_four.py
+++ b/logic/connect_four.py
@@ -20,13 +20,14 @@ class ConnectFour:
         return False
 
     def is_connected(self, x: int) -> bool:
-        y = min(
-            [
-                y
-                for y in reversed(range(self.board.size.y))
-                if not self.board.can_put_cell(Point(x, y))
-            ]
-        )
+        filled_y = [
+            y
+            for y in reversed(range(self.board.size.y))
+            if not self.board.can_put_cell(Point(x, y))
+        ]
+        if not filled_y:
+            return False
+        y = min(filled_y)
         if self.board.is_connected(Point(x, y)):
             return True
         return False

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,26 @@
 [[package]]
+name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "attrs"
+version = "21.2.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
+
+[[package]]
 name = "black"
 version = "21.12b0"
 description = "The uncompromising code formatter."
@@ -57,6 +79,14 @@ pycodestyle = ">=2.8.0,<2.9.0"
 pyflakes = ">=2.4.0,<2.5.0"
 
 [[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "isort"
 version = "5.10.1"
 description = "A Python utility / library to sort Python imports."
@@ -104,6 +134,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "packaging"
+version = "21.3"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
 name = "pathspec"
 version = "0.9.0"
 description = "Utility library for gitignore style pattern matching of file paths."
@@ -124,6 +165,26 @@ docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-
 test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
 
 [[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "pycodestyle"
 version = "2.8.0"
 description = "Python style guide checker"
@@ -138,6 +199,38 @@ description = "passive checker of Python programs"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pyparsing"
+version = "3.0.6"
+description = "Python parsing module"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
+name = "pytest"
+version = "6.2.5"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+py = ">=1.8.2"
+toml = "*"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
 name = "toml"
@@ -166,9 +259,17 @@ python-versions = ">=3.6"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "b21b1b772183d4467f16b2a54277180967d1ea398ab1bd93e93a22d488f62a10"
+content-hash = "0163efc5d5076c3cb0e0c67a915f4559d5beee7cf2b72c99049b2fb01408fa05"
 
 [metadata.files]
+atomicwrites = [
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+]
+attrs = [
+    {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
+    {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
+]
 black = [
     {file = "black-21.12b0-py3-none-any.whl", hash = "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"},
     {file = "black-21.12b0.tar.gz", hash = "sha256:77b80f693a569e2e527958459634f18df9b0ba2625ba4e0c2d5da5be42e6f2b3"},
@@ -184,6 +285,10 @@ colorama = [
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
     {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
+]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 isort = [
     {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
@@ -222,6 +327,10 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
+packaging = [
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
@@ -230,6 +339,14 @@ platformdirs = [
     {file = "platformdirs-2.4.0-py3-none-any.whl", hash = "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"},
     {file = "platformdirs-2.4.0.tar.gz", hash = "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2"},
 ]
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+py = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
 pycodestyle = [
     {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
     {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
@@ -237,6 +354,14 @@ pycodestyle = [
 pyflakes = [
     {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
     {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
+]
+pyparsing = [
+    {file = "pyparsing-3.0.6-py3-none-any.whl", hash = "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4"},
+    {file = "pyparsing-3.0.6.tar.gz", hash = "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"},
+]
+pytest = [
+    {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
+    {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ black = "^21.12b0"
 flake8 = "^4.0.1"
 isort = "^5.10.1"
 mypy = "^0.910"
+pytest = "^6.2.5"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,4 +28,4 @@ warn_unused_configs = True
 warn_unused_ignores = True
 
 [isort]
-line_length = 88
+profile = black

--- a/tests/logic/test_connect_four.py
+++ b/tests/logic/test_connect_four.py
@@ -1,0 +1,217 @@
+from typing import List
+
+import pytest
+
+from logic.cell import CellState
+from logic.connect_four import ConnectFour
+
+
+class TestConnectFour:
+    CELL_CHARACTER = {
+        "O": CellState.PLAYER,
+        "X": CellState.OPPONENT,
+        ".": CellState.EMPTY,
+    }
+
+    def generate_cells_from_lines(self, lines: List[str]) -> List[List[CellState]]:
+        cells = []
+        for line in lines:
+            cells.append([self.CELL_CHARACTER[cell] for cell in line])
+        return cells
+
+    def test_put_player_cell(self) -> None:
+        connect_four = ConnectFour()
+        connect_four.put_player_cell(0)
+        board_str = [
+            ".......",
+            ".......",
+            ".......",
+            ".......",
+            ".......",
+            "O......",
+        ]
+        expected = self.generate_cells_from_lines(board_str)
+        assert connect_four.board.cells == expected
+
+    def test_put_opponent_cell(self) -> None:
+        connect_four = ConnectFour()
+        connect_four.put_opponent_cell(0)
+        board_str = [
+            ".......",
+            ".......",
+            ".......",
+            ".......",
+            ".......",
+            "X......",
+        ]
+        expected = self.generate_cells_from_lines(board_str)
+        assert connect_four.board.cells == expected
+
+    def test_can_put_cell(self) -> None:
+        pass
+
+    @pytest.mark.parametrize(
+        "x, expected",
+        [
+            (0, True),
+            (1, True),
+            (2, True),
+            (3, True),
+            (4, False),
+            (5, False),
+            (6, False),
+        ],
+    )
+    def test_is_connected_horizontal(self, x: int, expected: bool) -> None:
+        connect_four = ConnectFour()
+        board_str = [
+            ".......",
+            ".......",
+            ".......",
+            ".......",
+            ".......",
+            "OOOO...",
+        ]
+        connect_four.board.cells = self.generate_cells_from_lines(board_str)
+        assert connect_four.is_connected(x) == expected
+
+    @pytest.mark.parametrize(
+        "x, expected",
+        [
+            (0, True),
+            (1, False),
+            (2, False),
+            (3, False),
+            (4, False),
+            (5, False),
+            (6, False),
+        ],
+    )
+    def test_is_connected_vertical(self, x: int, expected: bool) -> None:
+        connect_four = ConnectFour()
+        board_str = [
+            ".......",
+            ".......",
+            "O......",
+            "O......",
+            "O......",
+            "O......",
+        ]
+        connect_four.board.cells = self.generate_cells_from_lines(board_str)
+        assert connect_four.is_connected(x) == expected
+
+    @pytest.mark.parametrize(
+        "x, expected",
+        [
+            (0, True),
+            (1, True),
+            (2, True),
+            (3, True),
+            (4, False),
+            (5, False),
+            (6, False),
+        ],
+    )
+    def test_is_connected_right_diagonal(self, x: int, expected: bool) -> None:
+        connect_four = ConnectFour()
+        board_str = [
+            ".......",
+            ".......",
+            "...O...",
+            "..O....",
+            ".O.....",
+            "O......",
+        ]
+        connect_four.board.cells = self.generate_cells_from_lines(board_str)
+        assert connect_four.is_connected(x) == expected
+
+    @pytest.mark.parametrize(
+        "x, expected",
+        [
+            (0, False),
+            (1, False),
+            (2, False),
+            (3, True),
+            (4, True),
+            (5, True),
+            (6, True),
+        ],
+    )
+    def test_is_connected_left_diagonal(self, x: int, expected: bool) -> None:
+        connect_four = ConnectFour()
+        board_str = [
+            ".......",
+            ".......",
+            "...O...",
+            "....O..",
+            ".....O.",
+            "......O",
+        ]
+        connect_four.board.cells = self.generate_cells_from_lines(board_str)
+        assert connect_four.is_connected(x) == expected
+
+    @pytest.mark.parametrize("x", [0, 1, 2, 3, 4, 5, 6])
+    def test_is_connected_false_horizontal(self, x: int) -> None:
+        connect_four = ConnectFour()
+        board_str = [
+            ".......",
+            ".......",
+            ".......",
+            ".......",
+            ".......",
+            "XXX....",
+        ]
+        connect_four.board.cells = self.generate_cells_from_lines(board_str)
+        assert not connect_four.is_connected(x)
+
+    @pytest.mark.parametrize("x", [0, 1, 2, 3, 4, 5, 6])
+    def test_is_connected_false_vertical(self, x: int) -> None:
+        connect_four = ConnectFour()
+        board_str = [
+            ".......",
+            ".......",
+            ".......",
+            "X......",
+            "X......",
+            "X......",
+        ]
+        connect_four.board.cells = self.generate_cells_from_lines(board_str)
+        assert not connect_four.is_connected(x)
+
+    @pytest.mark.parametrize("x", [0, 1, 2, 3, 4, 5, 6])
+    def test_is_connected_false_right_diagonal(self, x: int) -> None:
+        connect_four = ConnectFour()
+        board_str = [
+            ".......",
+            ".......",
+            ".......",
+            "..X....",
+            ".X.....",
+            "X......",
+        ]
+        connect_four.board.cells = self.generate_cells_from_lines(board_str)
+        assert not connect_four.is_connected(x)
+
+    @pytest.mark.parametrize("x", [0, 1, 2, 3, 4, 5, 6])
+    def test_is_connected_false_left_diagonal(self, x: int) -> None:
+        connect_four = ConnectFour()
+        board_str = [
+            ".......",
+            ".......",
+            ".......",
+            "....X..",
+            ".....X.",
+            "......X",
+        ]
+        connect_four.board.cells = self.generate_cells_from_lines(board_str)
+        assert not connect_four.is_connected(x)
+
+    @pytest.mark.parametrize("x", [0, 1, 2, 3, 4, 5, 6])
+    def test_is_valid_x_true(self, x: int) -> None:
+        connect_four = ConnectFour()
+        assert connect_four.is_valid_x(x)
+
+    @pytest.mark.parametrize("x", [-1, 7])
+    def test_is_valid_x_false(self, x: int) -> None:
+        connect_four = ConnectFour()
+        assert not connect_four.is_valid_x(x)


### PR DESCRIPTION
Fix #3

## 変更内容
- pytestを使ったテストを実装しました。
- テストで見つかったバグを修正しました。
  - logic/board.py：斜め判定が片方しかできていなかったのを修正。
  - logic/connect_four.py：`is_connected` で引数 `x` にplayer, opponentセルがない場合エラーになるのを修正
- isortをblackの設定に合わせるように。
  - 参考：https://pycqa.github.io/isort/docs/configuration/black_compatibility.html
- READMEに開発者向け情報を追加。