### PR TITLE
test, lintをするworkflowを追加

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,33 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Test and Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v2.1.3
+
+      - name: Install dev-dependencies
+        run: poetry install --no-root
+
+      - name: Lint
+        run: make lint
+
+      - name: Test with pytest
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,14 @@ game:
 	python main.py
 
 test:
-	python -m pytest
+	poetry run python -m pytest
 
 lint:
-	black --check .
-	flake8 .
-	mypy .
-	isort --diff .
+	poetry run black --check .
+	poetry run flake8 .
+	poetry run mypy .
+	poetry run isort --diff .
 
 format:
-	black .
-	isort .
+	poetry run black .
+	poetry run isort .

--- a/cui/game.py
+++ b/cui/game.py
@@ -1,5 +1,9 @@
-from cui.display import (display_board, display_input_message, display_turn_info,
-                         display_winner_message)
+from cui.display import (
+    display_board,
+    display_input_message,
+    display_turn_info,
+    display_winner_message,
+)
 from logic.connect_four import ConnectFour
 
 


### PR DESCRIPTION
Fix #9

## 変更点
- タイトルの通り、make testとmake lintをするworkflowを追加しました。
- 追加に伴い、以下の変更を行いました。
  - Makefile：`make game` 以外のコマンドは `poetry run` で実行するようにしました。
    - `make game` に追加パッケージは不要なため、`poetry run` はつけていません。
  - cui/game.py：formatしそこねていたため、formatしました。