### PR TITLE
引き分け判定の実装

### DIFF
--- a/cui/display.py
+++ b/cui/display.py
@@ -44,6 +44,11 @@ def display_winner_message(is_player_turn: bool) -> None:
     print(f"{PLAYER_NAME[is_player_turn]} wins!")
 
 
+def display_draw_message() -> None:
+    print()
+    print("Draw!")
+
+
 def _clear_screen() -> None:
     print(ESC_CLEAR_SCREEN)
 

--- a/cui/game.py
+++ b/cui/game.py
@@ -1,5 +1,6 @@
 from cui.display import (
     display_board,
+    display_draw_message,
     display_input_message,
     display_turn_info,
     display_winner_message,
@@ -21,6 +22,7 @@ class Game:
                 break
             if self.connect_four.judge_draw():
                 display_board(self.connect_four.board)
+                display_draw_message()
                 break
             self.is_player_turn = not self.is_player_turn
 

--- a/cui/game.py
+++ b/cui/game.py
@@ -19,6 +19,9 @@ class Game:
                 display_board(self.connect_four.board)
                 display_winner_message(self.is_player_turn)
                 break
+            if self.connect_four.judge_draw():
+                display_board(self.connect_four.board)
+                break
             self.is_player_turn = not self.is_player_turn
 
     def _process_turn(self) -> int:

--- a/cui/game.py
+++ b/cui/game.py
@@ -16,7 +16,7 @@ class Game:
     def run(self) -> None:
         while True:
             x = self._process_turn()
-            if self.connect_four.is_connected(x):
+            if self.connect_four.judge_win(x):
                 display_board(self.connect_four.board)
                 display_winner_message(self.is_player_turn)
                 break

--- a/logic/board.py
+++ b/logic/board.py
@@ -33,6 +33,15 @@ class Board:
             return True
         return False
 
+    def has_any_empty_cell(self) -> bool:
+        for y in range(self.size.y):
+            can_put_cell = any(
+                [self.can_put_cell(Point(x, y)) for x in range(self.size.x)]
+            )
+            if can_put_cell:
+                return True
+        return False
+
     def _is_connected_vertical(self, pos: Point) -> bool:
         return self._is_connected_line(pos, Point(0, 1))
 

--- a/logic/connect_four.py
+++ b/logic/connect_four.py
@@ -23,7 +23,7 @@ class ConnectFour:
             return True
         return False
 
-    def is_connected(self, x: int) -> bool:
+    def judge_win(self, x: int) -> bool:
         filled_y = self._get_filled_y(x)
         if not filled_y:
             return False

--- a/logic/connect_four.py
+++ b/logic/connect_four.py
@@ -32,6 +32,11 @@ class ConnectFour:
             return True
         return False
 
+    def judge_draw(self) -> bool:
+        if self.board.has_any_empty_cell():
+            return False
+        return True
+
     def _get_filled_y(self, x: int) -> List[int]:
         filled_y = [
             y

--- a/tests/logic/test_connect_four.py
+++ b/tests/logic/test_connect_four.py
@@ -94,7 +94,7 @@ class TestConnectFour:
             (6, False),
         ],
     )
-    def test_is_connected_horizontal(self, x: int, expected: bool) -> None:
+    def test_judge_win_horizontal(self, x: int, expected: bool) -> None:
         connect_four = ConnectFour()
         board_str = [
             ".......",
@@ -105,7 +105,7 @@ class TestConnectFour:
             "OOOO...",
         ]
         connect_four.board.cells = self.generate_cells_from_lines(board_str)
-        assert connect_four.is_connected(x) == expected
+        assert connect_four.judge_win(x) == expected
 
     @pytest.mark.parametrize(
         "x, expected",
@@ -119,7 +119,7 @@ class TestConnectFour:
             (6, False),
         ],
     )
-    def test_is_connected_vertical(self, x: int, expected: bool) -> None:
+    def test_judge_win_vertical(self, x: int, expected: bool) -> None:
         connect_four = ConnectFour()
         board_str = [
             ".......",
@@ -130,7 +130,7 @@ class TestConnectFour:
             "O......",
         ]
         connect_four.board.cells = self.generate_cells_from_lines(board_str)
-        assert connect_four.is_connected(x) == expected
+        assert connect_four.judge_win(x) == expected
 
     @pytest.mark.parametrize(
         "x, expected",
@@ -144,7 +144,7 @@ class TestConnectFour:
             (6, False),
         ],
     )
-    def test_is_connected_right_diagonal(self, x: int, expected: bool) -> None:
+    def test_judge_win_right_diagonal(self, x: int, expected: bool) -> None:
         connect_four = ConnectFour()
         board_str = [
             ".......",
@@ -155,7 +155,7 @@ class TestConnectFour:
             "O......",
         ]
         connect_four.board.cells = self.generate_cells_from_lines(board_str)
-        assert connect_four.is_connected(x) == expected
+        assert connect_four.judge_win(x) == expected
 
     @pytest.mark.parametrize(
         "x, expected",
@@ -169,7 +169,7 @@ class TestConnectFour:
             (6, True),
         ],
     )
-    def test_is_connected_left_diagonal(self, x: int, expected: bool) -> None:
+    def test_judge_win_left_diagonal(self, x: int, expected: bool) -> None:
         connect_four = ConnectFour()
         board_str = [
             ".......",
@@ -180,10 +180,10 @@ class TestConnectFour:
             "......O",
         ]
         connect_four.board.cells = self.generate_cells_from_lines(board_str)
-        assert connect_four.is_connected(x) == expected
+        assert connect_four.judge_win(x) == expected
 
     @pytest.mark.parametrize("x", [0, 1, 2, 3, 4, 5, 6])
-    def test_is_connected_false_horizontal(self, x: int) -> None:
+    def test_judge_win_false_horizontal(self, x: int) -> None:
         connect_four = ConnectFour()
         board_str = [
             ".......",
@@ -194,10 +194,10 @@ class TestConnectFour:
             "XXX....",
         ]
         connect_four.board.cells = self.generate_cells_from_lines(board_str)
-        assert not connect_four.is_connected(x)
+        assert not connect_four.judge_win(x)
 
     @pytest.mark.parametrize("x", [0, 1, 2, 3, 4, 5, 6])
-    def test_is_connected_false_vertical(self, x: int) -> None:
+    def test_judge_win_false_vertical(self, x: int) -> None:
         connect_four = ConnectFour()
         board_str = [
             ".......",
@@ -208,10 +208,10 @@ class TestConnectFour:
             "X......",
         ]
         connect_four.board.cells = self.generate_cells_from_lines(board_str)
-        assert not connect_four.is_connected(x)
+        assert not connect_four.judge_win(x)
 
     @pytest.mark.parametrize("x", [0, 1, 2, 3, 4, 5, 6])
-    def test_is_connected_false_right_diagonal(self, x: int) -> None:
+    def test_judge_win_false_right_diagonal(self, x: int) -> None:
         connect_four = ConnectFour()
         board_str = [
             ".......",
@@ -222,10 +222,10 @@ class TestConnectFour:
             "X......",
         ]
         connect_four.board.cells = self.generate_cells_from_lines(board_str)
-        assert not connect_four.is_connected(x)
+        assert not connect_four.judge_win(x)
 
     @pytest.mark.parametrize("x", [0, 1, 2, 3, 4, 5, 6])
-    def test_is_connected_false_left_diagonal(self, x: int) -> None:
+    def test_judge_win_false_left_diagonal(self, x: int) -> None:
         connect_four = ConnectFour()
         board_str = [
             ".......",
@@ -236,4 +236,5 @@ class TestConnectFour:
             "......X",
         ]
         connect_four.board.cells = self.generate_cells_from_lines(board_str)
-        assert not connect_four.is_connected(x)
+        assert not connect_four.judge_win(x)
+

--- a/tests/logic/test_connect_four.py
+++ b/tests/logic/test_connect_four.py
@@ -238,3 +238,28 @@ class TestConnectFour:
         connect_four.board.cells = self.generate_cells_from_lines(board_str)
         assert not connect_four.judge_win(x)
 
+    def test_judge_draw_true(self) -> None:
+        connect_four = ConnectFour()
+        board_str = [
+            "OOOXOOO",
+            "XXXOXXX",
+            "OOOXOOO",
+            "XXXOXXX",
+            "OOOXOOO",
+            "XXXOXXX",
+        ]
+        connect_four.board.cells = self.generate_cells_from_lines(board_str)
+        assert connect_four.judge_draw()
+
+    def test_judge_draw_false(self) -> None:
+        connect_four = ConnectFour()
+        board_str = [
+            "OOOXOO.",
+            "XXXOXXX",
+            "OOOXOOO",
+            "XXXOXXX",
+            "OOOXOOO",
+            "XXXOXXX",
+        ]
+        connect_four.board.cells = self.generate_cells_from_lines(board_str)
+        assert not connect_four.judge_draw()


### PR DESCRIPTION
Fix #7

## 変更内容
ConnectFour
- judge_drawを実装し、引き分け判定を行えるようにしました。
  - 内部的には、Board.has_any_empty_cellを呼び出しています。
- is_connectedをjudge_winにリネームしました。
  - judge_drawと統一感を持たせるため。

Game
- ConnectFour.judge_drawを使って引き分け判定をするように。
- 引き分けなら `Draw!` と表示します。